### PR TITLE
docs: install gatsby-cli ang generate new proyect

### DIFF
--- a/content/posts/gatsby-deploy-firebase/index.mdx
+++ b/content/posts/gatsby-deploy-firebase/index.mdx
@@ -13,13 +13,13 @@ Lo primero es tener un sitio, o blog, con Gatsby. En futuros posts hablaré sobr
 Para ello, primero necesitamos tener instalado `node.js` en nuestro equipo para poder instalar el CLI de gatsby de forma global con:
 
 ```
-$ npm install -g gatsby-CLI
+$ npm install -g gatsby-cli
 ```
 
 Una vez instalado podemos usar el siguiente comando para iniciar un nuevo proyecto en Gatsby empleando el starter. Esto nos ahorrará tener que ficheros y carpetas.
 
 ```
-$ gatsby new TU_BLOG gatsby-starter-blog
+$ gatsby new TU_BLOG https://github.com/gatsbyjs/gatsby-starter-blog
 ```
 Sustituyendo `TU_BLOG` por el nombre que tu quieras. Una vez instalado si ejecutamos lo siguiente tendremos el blog corriendo en local en nuestro equipo en http://localhost:8000
 


### PR DESCRIPTION
"gatsby-CLI" it's not exists, changed to "gatsby-cli". To generate now a new project with the starter template you must pass the link of GitHub repository ("https://github.com/gatsbyjs/gatsby-starter-blog") instead of "gatsby-starter-blog".